### PR TITLE
fmt/save: fix `clippy::manual_unwrap_or_default` warning

### DIFF
--- a/src/fmt/save.rs
+++ b/src/fmt/save.rs
@@ -132,11 +132,7 @@ impl EncodedMessage {
     }
 
     pub fn msg(&self) -> Vec<u8> {
-        if let Ok(v) = Base64Engine.decode(&self.data) {
-            v
-        } else {
-            Vec::new()
-        }
+        Base64Engine.decode(&self.data).unwrap_or_default()
     }
 
     pub fn time(&self) -> Option<SystemTime> {


### PR DESCRIPTION
This commit fixes the following clippy warning:

warning: if let can be simplified with `.unwrap_or_default()`
   --> src/fmt/save.rs:135:9
    |
135 | /         if let Ok(v) = Base64Engine.decode(&self.data) {
136 | |             v
137 | |         } else {
138 | |             Vec::new()
139 | |         }
    | |_________^ help: replace it with: `Base64Engine.decode(&self.data).unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
    = note: `#[warn(clippy::manual_unwrap_or_default)]` on by default

warning: `ch4` (bin "ch4") generated 1 warning (run `cargo clippy --fix --bin "ch4"` to apply 1 suggestion)