### PR TITLE
args: use `clap` instead of `structopt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -281,17 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,11 +461,11 @@ dependencies = [
  "built",
  "cfg-if",
  "chrono",
+ "clap",
  "rsdns",
  "serde",
  "serde_json",
  "smol",
- "structopt",
  "sysinfo",
  "tera",
  "tokio",
@@ -481,18 +510,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrent-queue"
@@ -781,21 +841,9 @@ checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -896,6 +944,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1243,30 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,33 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1663,15 +1669,6 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1870,18 +1867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +1876,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "value-bag"
@@ -1903,12 +1894,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-features = false
 [dependencies]
 cfg-if = "1.0.0"
 anyhow = "1.0.42"
-structopt = "0.3.22"
+clap = { version = "4.5.20", features = ["derive"] }
 chrono = "0.4.19"
 base64 = "0.22.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use clap::Parser;
 use rsdns::{
     clients::{ClientConfig, EDns, ProtocolStrategy, Recursion},
     records::Type,
@@ -9,7 +10,6 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-use structopt::StructOpt;
 
 #[allow(dead_code)]
 pub mod bi {
@@ -25,60 +25,60 @@ pub enum OutputFormat {
     Rust,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "DNS Client", version = env!("CH4_VERSION"))]
+#[derive(Debug, Parser)]
+#[command(about = "DNS Client", version = env!("CH4_VERSION"))]
 pub struct Args {
     #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
-    #[structopt(short, long)]
+    #[arg(short, long)]
     bind_device: Option<String>,
 
-    #[structopt(short, long, default_value = "53")]
+    #[arg(short, long, default_value = "53")]
     port: u16,
 
-    #[structopt(
-        short = "l",
+    #[arg(
+        short = 'l',
         long,
         default_value = "10000",
         help = "query lifetime (in msec)."
     )]
     query_lifetime: u64,
 
-    #[structopt(
-        short = "t",
+    #[arg(
+        short = 't',
         long,
         default_value = "2000",
         help = "query timeout (in msec). Use 0 to disable."
     )]
     query_timeout: u64,
 
-    #[structopt(long, help = "Prints build information")]
+    #[arg(long, help = "Prints build information")]
     info: bool,
 
-    #[structopt(long, help = "Lists system nameservers")]
+    #[arg(long, help = "Lists system nameservers")]
     list_nameservers: bool,
 
-    #[structopt(skip)]
+    #[arg(skip)]
     pub format: OutputFormat,
 
-    #[structopt(skip)]
+    #[arg(skip)]
     pub config: ClientConfig,
 
-    #[structopt(skip)]
+    #[arg(skip)]
     pub qtype: Option<Type>,
 
-    #[structopt(skip)]
+    #[arg(skip)]
     pub qnames: Vec<String>,
 
-    #[structopt(skip)]
+    #[arg(skip)]
     pub nameservers: Vec<String>,
 
-    #[structopt(short = "s", long = "save", help = "save responses to file")]
+    #[arg(short = 's', long = "save", help = "save responses to file")]
     pub save_path: Option<String>,
 
-    #[structopt(short = "r", long = "read", help = "read responses from file")]
+    #[arg(short = 'r', long = "read", help = "read responses from file")]
     pub read_path: Option<String>,
 
-    #[structopt(verbatim_doc_comment)]
+    #[arg(verbatim_doc_comment)]
     /// Positional arguments ...
     ///
     /// Positional arguments may be specified without any particular order.
@@ -130,7 +130,7 @@ pub struct Args {
 
 impl Args {
     pub fn get() -> Result<Args> {
-        let mut args = Args::from_args();
+        let mut args = Args::parse();
 
         if args.info {
             Args::show_info();
@@ -142,7 +142,7 @@ impl Args {
             exit(0);
         }
 
-        args.parse()?;
+        args.parse_args()?;
 
         Ok(args)
     }
@@ -220,7 +220,7 @@ impl Args {
         Ok(())
     }
 
-    fn parse(&mut self) -> Result<()> {
+    fn parse_args(&mut self) -> Result<()> {
         let mut protocol_strategy = ProtocolStrategy::Udp;
         let mut nameserver_ip_addr: Option<IpAddr> = None;
         let mut recursion = Recursion::On;


### PR DESCRIPTION
`structopt` is unmaintained. This commit moves `ch4` to use `clap`
instead. `clap` contains most of `structopt's` functionality now.

This also removes `atty` indirect dependency which was recently raised
by GH security alerts [1].

[1] https://github.com/r-bk/ch4/security/dependabot/1
