### PR TITLE
Add support for `SRV` records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-04-25
+
+### Added
+
+- add support for `SRV` records
+
+### Changed
+
+- upgrade to `rsdns v0.23.0`
+
 ## [0.19.0] - 2026-04-22
 
 ### Changed
@@ -517,3 +527,4 @@ This release only refreshes the dependencies, without changing anything in *ch4*
 [0.18.0]: https://github.com/r-bk/ch4/compare/v0.17.0...v0.18.0
 [0.18.1]: https://github.com/r-bk/ch4/compare/v0.18.0...v0.18.1
 [0.19.0]: https://github.com/r-bk/ch4/compare/v0.18.1...v0.19.0
+[0.20.0]: https://github.com/r-bk/ch4/compare/v0.19.0...v0.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,3 +516,4 @@ This release only refreshes the dependencies, without changing anything in *ch4*
 [0.17.0]: https://github.com/r-bk/ch4/compare/v0.16.0...v0.17.0
 [0.18.0]: https://github.com/r-bk/ch4/compare/v0.17.0...v0.18.0
 [0.18.1]: https://github.com/r-bk/ch4/compare/v0.18.0...v0.18.1
+[0.19.0]: https://github.com/r-bk/ch4/compare/v0.18.1...v0.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ch4"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,9 +1128,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rsdns"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c75f577d34947f4cd59d0f663906e34f5623b638a8337ba63477945ee301a"
+checksum = "b7b0aaeba401ddd7fd629335d4147278e9e13acec42dc6fb9fb90307409378e7"
 dependencies = [
  "arrayvec",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ net-smol = ["rsdns/net-smol", "smol"]
 socket2 = ["rsdns/socket2"]
 
 [dependencies.rsdns]
-version = "0.22.0"
+version = "0.23.0"
 default-features = false
 # path = "dep/rsdns"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ch4"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Rafael Buchbinder <rafi@rbk.io>"]
 edition = "2024"
 description = "DNS Client Tool"

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -105,6 +105,7 @@ impl<'a> Format<'a> {
             Type::MX => Self::short_rrset::<data::Mx>(msg),
             Type::TXT => Self::short_rrset::<data::Txt>(msg),
             Type::AAAA => Self::short_rrset::<data::Aaaa>(msg),
+            Type::SRV => Self::short_rrset::<data::Srv>(msg),
             t if t.is_meta_type() => {
                 bail!("invalid qtype: {qtype}");
             }

--- a/src/fmt/rdata.rs
+++ b/src/fmt/rdata.rs
@@ -110,3 +110,10 @@ impl<W: Write> RDataFormatter<W, data::Aaaa> for RDataFmt {
         Ok(())
     }
 }
+
+impl<W: Write> RDataFormatter<W, data::Srv> for RDataFmt {
+    fn fmt(w: &mut W, d: &data::Srv) -> Result<()> {
+        write!(w, "{} {} {} {}", d.priority, d.weight, d.port, d.target)?;
+        Ok(())
+    }
+}

--- a/src/fmt/zone.rs
+++ b/src/fmt/zone.rs
@@ -246,6 +246,10 @@ impl<'a, 'b> Output<'a, 'b> {
                     let hinfo = mr.record_data::<Hinfo>(rec_header.marker())?;
                     RDataFmt::fmt(&mut output, &hinfo)?;
                 }
+                Type::SRV => {
+                    let srv = mr.record_data::<Srv>(rec_header.marker())?;
+                    RDataFmt::fmt(&mut output, &srv)?;
+                }
                 _ => {
                     let bytes = mr.record_data_bytes(rec_header.marker())?;
                     write!(&mut output, "{}", self.format_rfc_3597(bytes)?)?;


### PR DESCRIPTION
- **changelog: add missing diff link to v0.19.0**
- **dep: bump rsdns submodule to latest**
- **ch4: add support for SRV records**
- **changelog: seal v0.20.0**
- **cargo: bump the version to 0.20.0**
